### PR TITLE
Add dd() function to be globally available

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,10 @@
     "autoload": {
         "psr-4": {
             "PMG\\Support\\": "src/"
-        }
+        },
+        "files": [
+            "src/helpers.php"
+        ]
     },
     "autoload-dev": {
         "psr-4": {

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -7,3 +7,10 @@ if (!function_exists('dd')) {
         exit;
     }
 }
+
+if (!function_exists('d')) {
+    // Make the dd() function available for Laravel converts.
+    function d(...$params) {
+        dump($params);
+    }
+}

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -9,7 +9,6 @@ if (!function_exists('dd')) {
 }
 
 if (!function_exists('d')) {
-    // Make the dd() function available for Laravel converts.
     function d(...$params) {
         dump($params);
     }

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -1,0 +1,9 @@
+<?php declare(strict_types=1);
+
+if (!function_exists('dd')) {
+    // Make the dd() function available for Laravel converts.
+    function dd(...$params) {
+        dump($params);
+        exit;
+    }
+}


### PR DESCRIPTION
Working with Martin and using Laravel myself, one thing that I used all the time was the `dd()`. It's really nothing special, other than it is very quick to write. All it does is allow any number of arguments, passes them to Symfony's `dump()` function, and then `exit;` but instead of having to write d-u-m-p-(-$-a-r-g-)-;-e-x-i-t-; You can just do `d-d-(-$-a-r-g-)-;`

I know it doesn't seem like much, but as much as I "dump and die" to debug things. That `dd()` was pretty much just muscle memory.

Anyway, some concerns about the way I implemented it:
- This assumes that the Symofony/VarDumper component is available. We could add it as a dependency here...or we can handle in some other way.
- This would be available on Production...so we could limit it to an environment, but that would also add some dependency on figuring out if the app is in Prod or Dev.
- I am suggesting this to PMG\Support since I would want it on any app that I work on. But I am open to another location if that makes more sense. When I had to make Core -> Support changes on Actions, I became aware of this repo and seems like a fairly reasonable place for it to live.
- This could also be a place to add other functions that would be "app building" but not really application specific.